### PR TITLE
Error during iOS build

### DIFF
--- a/src/platforms/ios/Podfile
+++ b/src/platforms/ios/Podfile
@@ -1,2 +1,1 @@
-platform :ios, '8.0'
 pod 'ZXingObjC', '~> 3.4.0'


### PR DESCRIPTION
I've found that platform declaration in the podfile threw the duplicate platform declaration error during build for iOS. Without it, everything is working as expected. Could you please check it?